### PR TITLE
fix: multiple ball toggle bug

### DIFF
--- a/docs/models/components/Ball.js
+++ b/docs/models/components/Ball.js
@@ -22,7 +22,8 @@ class Ball {
     this.incSpeedTime = 1200;
     this.isBeingAbsorbed = false;
     this.minSpeedY = minSpeedY,
-    this.maxSppedY = maxSpeedY
+    this.maxSpeedY = maxSpeedY,
+    this.increaseSpeed = false
   }
 
   display(canvas = window) {
@@ -38,9 +39,14 @@ class Ball {
         this.speedY = this.y < this.gameHeight / 2 ? this.initialSpeedY : -this.initialSpeedY;
       }
     }
-    if (this.increaseSpeed && Math.abs(this.speedY) <= this.maxSppedY) {
+
+    if (this.increaseSpeed && Math.abs(this.speedY) <= this.maxSpeedY && !this.isIncreasingSpeed) {
       this.speedY *= this.incSpeedVal;
-      setTimeout(() => (this.speedY = Math.sign(this.speedY) * 5), this.incSpeedTime);
+      this.isIncreasingSpeed = true;
+      setTimeout(() => {
+        this.speedY = Math.sign(this.speedY) * this.initialSpeedY;
+        this.isIncreasingSpeed = false;
+      }, this.incSpeedTime);
     }
 
     const minSpeed = 1;
@@ -78,7 +84,9 @@ class Ball {
       this.applyPaddleBounce(paddle);
       if (stageController.state.paddle.toggleOn) {
         this.increaseSpeed = true;
-        setTimeout(() => (this.increaseSpeed = false), 300);
+        setTimeout(() => {
+          this.increaseSpeed = false;
+        }, 300)
       }
     }
   }


### PR DESCRIPTION
1. Fix `maxSpeedY` typo.
2. When `toggleOn` is activated for speed-up, set a flag `increaseSpeed` to prevent duplicate triggering of `setTimeout` for speed reduction, and gradually reduce speed back to the initial speed.
3. Refactor `setTimeout` usage.
